### PR TITLE
Module Name cannot be bigger than 64 characters

### DIFF
--- a/src/XALTdb.py
+++ b/src/XALTdb.py
@@ -254,6 +254,10 @@ class XALTdb(object):
           obj_kind   = obj_type(object_path)
 
           query      = "INSERT into xalt_object VALUES (NULL,%s,%s,%s,%s,NOW(),%s)"
+          
+          if moduleName:
+            if len(moduleName) > 64:
+              moduleName = moduleName[:63]
                       
           cursor.execute(query,(object_path, syshost, hash_id, moduleName, obj_kind))
           obj_id   = conn.insert_id()


### PR DESCRIPTION
We get the following error when the module name is greater than 64 characters:
```
root: ERROR "load_xalt_objects(): Error 1406: Data too long for column 'module_name' at row 1"
```
One way of solving this issue is truncating the module name. Which is this proposal.