### PR TITLE
Use make install/pre-install pattern

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -133,8 +133,10 @@ INIT_SRC             	:= $(patsubst %, $(srcdir)/%, $(INIT_SRC))
 all:
 	@echo done
 
-install:  $(DIRLIST) Inst_sbin Inst_bin Inst_libexec Use_getent_yes             \
+pre-install:  $(DIRLIST) Inst_sbin Inst_bin Inst_libexec Use_getent_yes             \
           Use_argparse_$(USE_ARGPARSE) build_compiled
+
+install: pre-install
 	$(RM) $(DESTDIR)$(PKG)
 	ln -s $(VERSION) $(DESTDIR)$(PKG)
 


### PR DESCRIPTION
Idea copied from Lmod.  Have always found the `make pre-install` pattern useful when installing new versions for testing to avoid updating the symlink.