### PR TITLE
Avoid division by zero errors

### DIFF
--- a/py_src/xalt_syslog_to_db.in.py
+++ b/py_src/xalt_syslog_to_db.in.py
@@ -379,6 +379,8 @@ def main():
   # Count the number and sum the run_time for all scalar jobs
 
   filter = Filter(100)
+  if fnSz == 0:
+    fnSz = 1
   pbar   = ProgressBar(maxVal=fnSz,fd=sys.stdout)
   for fn in fnA:
     if (not os.path.isfile(fn)):

--- a/py_src/xalt_usage_report.in.py
+++ b/py_src/xalt_usage_report.in.py
@@ -453,9 +453,18 @@ def kinds_of_jobs(cursor, args, startdate, enddate):
 
      
   for k, entryT in sorted(resultT.iteritems(), key=lambda(k,v): v['corehours'], reverse=True):
-    pSU = "%.0f" % (100.0 * entryT['corehours']/totalT['corehours'])
-    pR  = "%.0f" % (100.0 * entryT['n_runs']   /float(totalT['n_runs']))
-    pJ  = "%.0f" % (100.0 * entryT['n_jobs']   /float(totalT['n_jobs']))
+    if totalT['corehours'] != 0.0:
+        pSU = "%.0f" % (100.0 * entryT['corehours']/totalT['corehours'])
+    else:
+        pSU = 0.0
+    if totalT['n_runs'] != 0.0:
+        pR  = "%.0f" % (100.0 * entryT['n_runs']   /float(totalT['n_runs']))
+    else:
+        pR = 0.0
+    if totalT['n_jobs'] != 0.0:
+        pJ  = "%.0f" % (100.0 * entryT['n_jobs']   /float(totalT['n_jobs']))
+    else:
+        pJ = 0.0
 
     resultA.append([k,
       "%.0f" % (entryT['corehours']), pSU,


### PR DESCRIPTION
The `xalt_syslog_to_db.in.py` changes avoid division by zero when a log file is empty.  The change to `xalt_usage_report.in.py` was something I had to do during very early testing when database was empty and just wanted to test connectivity of usage script.

Replaces #27 