### PR TITLE
Resolve SLURM detection issue

### DIFF
--- a/src/translate.C
+++ b/src/translate.C
@@ -22,7 +22,7 @@ void translate(Table& envT, Table& userT, DTable& userDT)
     queueType = SGE;
   else if (envT.count("SLURM_TACC_ACCOUNT") || envT.count("SLURM_TACC_JOBNAME"))
     queueType = SLURM_TACC;
-  else if (envT.count("SBATCH_ACCOUNT"))
+  else if (envT.count("SBATCH_ACCOUNT") || envT.count("SLURM_JOB_ID"))
     queueType = SLURM;
   else if (envT.count("PBS_JOBID"))
     queueType = PBS;


### PR DESCRIPTION
XALT was not correctly detecting the resource manager on my cluster.  The `SBATCH_ACCOUNT` environment variable was not set.  Broadening the SLURM detection to trigger on `SLURM_JOB_ID` which should be more general.