### PR TITLE
Avoid potential division by zero on empty log files

### DIFF
--- a/py_src/xalt_syslog_to_db.in.py
+++ b/py_src/xalt_syslog_to_db.in.py
@@ -427,7 +427,7 @@ def main():
   badsyslog   = 0
   count       = 0
   parseSyslog = ParseSyslog(args.leftover)
-  pbar        = ProgressBar(maxVal=fnSz,fd=sys.stdout)
+  pbar        = ProgressBar(maxVal=max(fnSz,1),fd=sys.stdout)
   for fn in fnA:
     if (not os.path.isfile(fn)):
       continue


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/mnt/pitzer/xalt/xalt/sbin/xalt_syslog_to_db.py", line 503, in <module>
    if ( __name__ == '__main__'): main()
  File "/mnt/pitzer/xalt/xalt/sbin/xalt_syslog_to_db.py", line 430, in main
    pbar        = ProgressBar(maxVal=fnSz,fd=sys.stdout)
  File "/mnt/pitzer/xalt/2.3.2/libexec/progressBar.py", line 102, in __init__
    self.__unit     = 100/self.__barWidth
ZeroDivisionError: division by zero
```