### PR TITLE
Use mktemp for more robust temporary directory creation

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -63,6 +63,7 @@ PATH_TO_HEAD         	:= @PATH_TO_HEAD@
 PATH_TO_LDD          	:= @PATH_TO_LDD@
 PATH_TO_LOGGER       	:= @PATH_TO_LOGGER@
 PATH_TO_MKDIR        	:= @PATH_TO_MKDIR@
+PATH_TO_MKTEMP        	:= @PATH_TO_MKTEMP@
 PATH_TO_OBJDUMP      	:= @PATH_TO_OBJDUMP@
 PATH_TO_OTOOL        	:= @PATH_TO_OTOOL@
 PATH_TO_PSTREE       	:= @PATH_TO_PSTREE@
@@ -222,6 +223,7 @@ __installMe:
 	        -e 's|@path_to_cat@|$(PATH_TO_CAT)|g'                      	  \
 	        -e 's|@path_to_dirname@|$(PATH_TO_DIRNAME)|g'              	  \
 	        -e 's|@path_to_mkdir@|$(PATH_TO_MKDIR)|g'                  	  \
+	        -e 's|@path_to_mktemp@|$(PATH_TO_MKTEMP)|g'                  	  \
 	        -e 's|@path_to_pstree@|$(PATH_TO_PSTREE)|g'                	  \
 	        -e 's|@path_to_readlink@|$(PATH_TO_READLINK)|g'            	  \
 	        -e 's|@path_to_rm@|$(PATH_TO_RM)|g'                        	  \

--- a/configure
+++ b/configure
@@ -634,6 +634,7 @@ CPP
 HAVE_PYMOD_MYSQLDB
 PATH_TO_PYTHON
 PATH_TO_OTOOL
+PATH_TO_MKTEMP
 PATH_TO_FLEX
 USE_CONTRIB_ARGPARSE
 PATH_TO_UUIDGEN
@@ -4357,6 +4358,46 @@ $as_echo "no" >&6; }
 fi
 
 
+# Extract the first word of "mktemp", so it can be a program name with args.
+set dummy mktemp; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PATH_TO_MKTEMP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $PATH_TO_MKTEMP in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PATH_TO_MKTEMP="$PATH_TO_MKTEMP" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PATH_TO_MKTEMP="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+PATH_TO_MKTEMP=$ac_cv_path_PATH_TO_MKTEMP
+if test -n "$PATH_TO_MKTEMP"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PATH_TO_MKTEMP" >&5
+$as_echo "$PATH_TO_MKTEMP" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
 # Extract the first word of "objdump", so it can be a program name with args.
 set dummy objdump; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -4642,6 +4683,13 @@ fi
 
 
 
+if test "x${PATH_TO_MKTEMP}" = "x" ; then
+  as_fn_error $? "Unable to build XALT without mktemp" "$LINENO" 5
+fi
+
+if test "x${PATH_TO_UUIDGEN}" = "x" ; then
+  as_fn_error $? "Unable to build XALT without uuidgen" "$LINENO" 5
+fi
 
 transmission=`echo $TRANSMISSION | tr A-Z a-z`
 

--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,7 @@ AC_PATH_PROG(PATH_TO_HEAD, head, [])
 AC_PATH_PROG(PATH_TO_LDD, ldd, [])
 AC_PATH_PROG(PATH_TO_LOGGER, logger, [])
 AC_PATH_PROG(PATH_TO_MKDIR,mkdir, [])
+AC_PATH_PROG(PATH_TO_MKTEMP, mktemp, [])
 AC_PATH_PROG(PATH_TO_OBJDUMP, objdump, "")
 AC_PATH_PROG(PATH_TO_OTOOL, otool, "")
 AC_PATH_PROG(PATH_TO_PYTHON, python, "")
@@ -263,6 +264,13 @@ AC_PATH_PROG(PATH_TO_RM, rm, [])
 AC_PATH_PROG(PATH_TO_SHA1SUM, sha1sum, "")
 AC_PATH_PROG(PATH_TO_UUIDGEN,uuidgen, [])
 
+if test "x${PATH_TO_MKTEMP}" = "x" ; then
+  AC_MSG_ERROR([Unable to build XALT without mktemp])
+fi
+
+if test "x${PATH_TO_UUIDGEN}" = "x" ; then
+  AC_MSG_ERROR([Unable to build XALT without uuidgen])
+fi
 
 transmission=`echo $TRANSMISSION | tr A-Z a-z`
 

--- a/sh_src/ld.in
+++ b/sh_src/ld.in
@@ -204,13 +204,13 @@ UUIDGEN=@uuidgen@
 RM=@path_to_rm@
 AS=@path_to_as@
 CAT=@path_to_cat@
-MKDIR=@path_to_mkdir@
+MKTEMP=@path_to_mktemp@
 GREP=@grep@
 PyPATH="/usr/bin:/bin"
 
 
 UUID=`$UUIDGEN`
-WRKDIR=/tmp/${USER}_${DATESTR}_${UUID}
+WRKDIR=$(mktemp -d "${USER}_${UUID}_XXXXXX")
 LINKLINE_OUT=$WRKDIR/link.txt
 LINKLINE_ERR=$WRKDIR/link.err
 ARGSRC=$WRKDIR/xalt.s
@@ -231,11 +231,6 @@ else
   XALT_INIT_ROUTINE_OBJ="$XLD/xalt_initialize_32.o $XLD/xalt_syshost_32.o $XLD/xalt_quotestring_32.o $XLD/xalt_fgets_alloc_32.o $XLD/lex.__XALT_path_32.o $XLD/lex.__XALT_host_32.o $XLD/build_uuid_32.o $XLD/base64.o $XLD/my_hostname_parser_32.o"
 fi
   
-
-if [ ! -d $WRKDIR ]; then
-  $MKDIR -p $WRKDIR
-fi
-
 # Get the compiler information
 COMP_T=$(LD_LIBRARY_PATH=$CXX_LD_LIBRARY_PATH $EXTRACT_LINKER)
 tracing_msg "COMP_T:" $COMP_T 


### PR DESCRIPTION
`uuidgen` was missing on a cluster and didn't notice it since `configure` was "successful".  As a result, parallel makes (`make -j`) were failing because `WRKDIR` was not unique for each process.

Rather than construct a "unique" temporary directory name by hand, just use `mktemp`.

Also, updated `configure` to stop with an error if either mktemp or uuidgen is not found.