### PR TITLE
Changes to support injecting XALT inside Singularity containers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -28,6 +28,7 @@ CURRENT_MK        := $(lastword $(MAKEFILE_LIST))
 
 OS_NAME           := $(shell uname -s)
 LIB_OPTIONS       := -fPIC -shared
+LDFLAGS           := @LDFLAGS@
 ifeq ($(OS_NAME),Darwin)
   LIB_OPTIONS     := -bundle -undefined dynamic_lookup
 endif
@@ -49,6 +50,7 @@ XALT_V               	:= src/xalt_version.h
 SYSLOG_MSG_SZ        	:= @SYSLOG_MSG_SZ@
 HAVE_LIBUUID         	:= @HAVE_WORKING_LIBUUID@
 HAVE_DCGM         	:= @HAVE_DCGM@
+STATIC_LIBS             := @STATIC_LIBS@
 CXX_LD_LIBRARY_PATH  	:= @CXX_LD_LIBRARY_PATH@
 HAVE_32BIT           	:= @HAVE_32BIT@
 PATH_TO_AS           	:= @PATH_TO_AS@
@@ -145,9 +147,11 @@ install: $(DIRLIST) LINKS Inst_sbin Inst_bin Inst_libexec Use_getent_yes   \
 
 build_compiled:
 	cd src; $(MAKE) LD_PRELOAD= XALT_EXECUTABLE_TRACKING= PARENT_DIR=$(srcdir) DESTDIR=$(DESTDIR)      \
+                        LDFLAGS="$(LDFLAGS)" \
                         LIBEXEC=$(LIBEXEC) SBIN=$(SBIN) BIN=$(BIN) HAVE_32BIT=$(HAVE_32BIT) LIB=$(LIB)     \
                         OPTLVL="$(OPTLVL)" LIB64=$(LIB64) HAVE_LIBUUID=$(HAVE_LIBUUID)                     \
                         HAVE_DCGM=$(HAVE_DCGM) XALT_FILE_PREFIX=$(XALT_FILE_PREFIX)                        \
+                        STATIC_LIBS=$(STATIC_LIBS) \
                         MY_HOSTNAME_PARSER=$(MY_HOSTNAME_PARSER) all
 
 echo:

--- a/configure
+++ b/configure
@@ -660,6 +660,7 @@ CXXFLAGS
 CXX
 HAVE_32BIT
 BAD_INSTALL
+STATIC_LIBS
 MY_HOSTNAME_PARSER
 SYSHOST_CONFIG
 CXX_LD_LIBRARY_PATH
@@ -704,7 +705,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -743,6 +743,7 @@ with_syslogMsgSz
 with_cxxLDLibraryPath
 with_syshostConfig
 with_hostnameParser
+with_staticLibs
 with_IrefuseToInstallXALTCorrectly
 '
       ac_precious_vars='build_alias
@@ -795,7 +796,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1048,15 +1048,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1194,7 +1185,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1347,7 +1338,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1401,6 +1391,8 @@ Optional Packages:
                           Replace built-in lex based hostname parser
                           c_file:file.c or library:file_64.a or
                           library:file_64.a:file_32.a [[no]]
+  --with-staticLibs=ans   Link with static libraries (currently only
+                          libcrypto) [[no]]
   --with-IrefuseToInstallXALTCorrectly=ans
                           Install XALT incorrectly [[no]]
 
@@ -3393,6 +3385,28 @@ fi
 
 
 
+# Check whether --with-staticLibs was given.
+if test "${with_staticLibs+set}" = set; then :
+  withval=$with_staticLibs; STATIC_LIBS="$withval"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: STATIC_LIBS=$with_staticLibs" >&5
+$as_echo "STATIC_LIBS=$with_staticLibs" >&6; }
+    cat >>confdefs.h <<_ACEOF
+#define STATIC_LIBS "$with_staticLibs"
+_ACEOF
+
+else
+  withval="no"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: STATIC_LIBS=$withval" >&5
+$as_echo "STATIC_LIBS=$withval" >&6; }
+    STATIC_LIBS="$withval"
+    cat >>confdefs.h <<_ACEOF
+#define STATIC_LIBS "$withval"
+_ACEOF
+
+fi
+
+
+
 # Check whether --with-IrefuseToInstallXALTCorrectly was given.
 if test "${with_IrefuseToInstallXALTCorrectly+set}" = set; then :
   withval=$with_IrefuseToInstallXALTCorrectly; BAD_INSTALL="$withval"
@@ -5327,7 +5341,68 @@ else
 fi
 
 
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dcgmInit" >&5
+  if test "$STATIC_LIBS" = yes; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dcgmInit" >&5
+$as_echo_n "checking for library containing dcgmInit... " >&6; }
+if ${ac_cv_search_dcgmInit+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char dcgmInit ();
+int
+main ()
+{
+return dcgmInit ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' dcgm_stub; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib -ldl $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_dcgmInit=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_dcgmInit+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_dcgmInit+:} false; then :
+
+else
+  ac_cv_search_dcgmInit=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dcgmInit" >&5
+$as_echo "$ac_cv_search_dcgmInit" >&6; }
+ac_res=$ac_cv_search_dcgmInit
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+  $as_echo "#define USE_DCGM 1" >>confdefs.h
+ HAVE_DCGM=yes
+else
+  as_fn_error $? "Unable to include GPU tracking without DCGM" "$LINENO" 5
+fi
+
+  else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dcgmInit" >&5
 $as_echo_n "checking for library containing dcgmInit... " >&6; }
 if ${ac_cv_search_dcgmInit+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5386,6 +5461,7 @@ else
   as_fn_error $? "Unable to include GPU tracking without DCGM" "$LINENO" 5
 fi
 
+  fi
 fi
 
 
@@ -5509,7 +5585,67 @@ if test "$USE_CONTRIB_ARGPARSE" = yes; then
    fi
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing SHA1" >&5
+if test "$STATIC_LIBS" = yes; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing SHA1" >&5
+$as_echo_n "checking for library containing SHA1... " >&6; }
+if ${ac_cv_search_SHA1+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char SHA1 ();
+int
+main ()
+{
+return SHA1 ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' :libcrypto.a; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib -ldl -lz $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_SHA1=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_SHA1+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_SHA1+:} false; then :
+
+else
+  ac_cv_search_SHA1=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_SHA1" >&5
+$as_echo "$ac_cv_search_SHA1" >&6; }
+ac_res=$ac_cv_search_SHA1
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else
+  as_fn_error $? "Unable to build XALT without libcrypto.a" "$LINENO" 5
+fi
+
+else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing SHA1" >&5
 $as_echo_n "checking for library containing SHA1... " >&6; }
 if ${ac_cv_search_SHA1+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5567,6 +5703,7 @@ else
   as_fn_error $? "Unable to build XALT without libcrypto" "$LINENO" 5
 fi
 
+fi
 
 $PATH_TO_PYTHON $ac_confdir/py_build_tools/build_xalt_interval_table.py --confFn $XALT_CONFIG_PY --input $ac_confdir/src/tmpl/xalt_interval.template --output src/__build__/xalt_interval.h
 if test "$?" != 0; then

--- a/configure.ac
+++ b/configure.ac
@@ -201,6 +201,18 @@ AC_ARG_WITH(hostnameParser,
     MY_HOSTNAME_PARSER="$withval"
     AC_DEFINE_UNQUOTED(MY_HOSTNAME_PARSER, "$withval"))dnl
 
+AC_SUBST(STATIC_LIBS)
+AC_ARG_WITH(staticLibs,
+    AC_HELP_STRING([--with-staticLibs=ans],[Link with static libraries (currently only libcrypto) [[no]]]),
+    STATIC_LIBS="$withval"
+    AC_MSG_RESULT([STATIC_LIBS=$with_staticLibs])
+    AC_DEFINE_UNQUOTED(STATIC_LIBS, "$with_staticLibs")dnl
+    ,
+    withval="no"
+    AC_MSG_RESULT([STATIC_LIBS=$withval])
+    STATIC_LIBS="$withval"
+    AC_DEFINE_UNQUOTED(STATIC_LIBS, "$withval"))dnl
+
 AC_SUBST(BAD_INSTALL)
 AC_ARG_WITH(IrefuseToInstallXALTCorrectly,
     AC_HELP_STRING([--with-IrefuseToInstallXALTCorrectly=ans],[Install XALT incorrectly [[no]]]),
@@ -360,7 +372,11 @@ if test $XALT_GPU_TRACKING = yes; then
                   [AC_DEFINE([HAVE_DCGM_AGENT_H], 1,
                      [Define to 1 if you have DCGM.])],
                   [AC_MSG_ERROR([Unable to include GPU tracking without DCGM])])
-  AC_SEARCH_LIBS([dcgmInit], [dcgm], [AC_DEFINE(USE_DCGM, [1]) HAVE_DCGM=yes], [AC_MSG_ERROR([Unable to include GPU tracking without DCGM])])
+  if test "$STATIC_LIBS" = yes; then
+    AC_SEARCH_LIBS([dcgmInit], [dcgm_stub], [AC_DEFINE(USE_DCGM, [1]) HAVE_DCGM=yes], [AC_MSG_ERROR([Unable to include GPU tracking without DCGM])], [-ldl])
+  else
+    AC_SEARCH_LIBS([dcgmInit], [dcgm], [AC_DEFINE(USE_DCGM, [1]) HAVE_DCGM=yes], [AC_MSG_ERROR([Unable to include GPU tracking without DCGM])])
+  fi
 fi
 AC_SUBST(PKGV)
 AC_SUBST(VERSION)
@@ -484,7 +500,11 @@ if test "$USE_CONTRIB_ARGPARSE" = yes; then
    fi
 fi
 
-AC_SEARCH_LIBS([SHA1], [crypto], [], [AC_MSG_ERROR([Unable to build XALT without libcrypto])])
+if test "$STATIC_LIBS" = yes; then
+    AC_SEARCH_LIBS([SHA1], [:libcrypto.a], [], [AC_MSG_ERROR([Unable to build XALT without libcrypto.a])], [-ldl -lz])
+else
+    AC_SEARCH_LIBS([SHA1], [crypto], [], [AC_MSG_ERROR([Unable to build XALT without libcrypto])])
+fi
 
 $PATH_TO_PYTHON $ac_confdir/py_build_tools/build_xalt_interval_table.py --confFn $XALT_CONFIG_PY --input $ac_confdir/src/tmpl/xalt_interval.template --output src/__build__/xalt_interval.h
 if test "$?" != 0; then

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -7,7 +7,16 @@ ifeq ($(HAVE_LIBUUID),yes)
   HAVE_UUID:=-DHAVE_LIBUUID
 endif
 ifeq ($(HAVE_DCGM),yes)
-  LIBDCGM:=-ldcgm
+  ifeq ($(STATIC_LIBS),yes)
+    LIBDCGM:=-ldcgm_stub -ldl
+  else
+    LIBDCGM:=-ldcgm
+  endif
+endif
+ifeq ($(STATIC_LIBS),yes)
+  LIBCRYPTO:=-l:libcrypto.a -ldl -lz
+else
+  LIBCRYPTO:=-lcrypto
 endif
 
 ifneq ($(XALT_FILE_PREFIX),USE_HOME)
@@ -185,46 +194,46 @@ my_hostname_parser_target_32:
 	cp $(MY_HOSTNAME_PARSER_LIB32)     $(DESTDIR)$(LIB)/my_hostname_parser_32.a
 
 $(TRP_EXEC) : $(TRP_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ 
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(XRP_EXEC) : $(XRP_OBJS)
-	$(LINK.c) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ -lz $(LIBUUID)
+	$(LINK.c) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^ -lz $(LIBUUID)
 
 $(XRS_EXEC) : $(XRS_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ -lz -lcrypto -lpthread 
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^ -lz -lpthread $(LIBCRYPTO)
 
 $(XGA_EXEC): $(XGA_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(XGL_EXEC): $(XGL_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ -lz -lcrypto -lpthread
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^ -lz -lpthread $(LIBCRYPTO)
 
 $(XEL_EXEC) : $(XEL_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(XSL_EXEC) : $(XSL_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(XCR_EXEC) : $(XCR_OBJS) 
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ 
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(XER_EXEC) : $(XER_OBJS) 
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ 
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(F2DB_EXEC) : $(F2DB_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ -lz $(MYSQL_LDFLAGS)
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^ -lz $(MYSQL_LDFLAGS)
 
 $(S2DB_EXEC) : $(S2DB_OBJS)
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^ -lz $(MYSQL_LDFLAGS)
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^ -lz $(MYSQL_LDFLAGS)
 
 $(DESTDIR)$(LIBEXEC)/xalt_realpath: xalt_realpath.o
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(DESTDIR)$(LIBEXEC)/xalt_epoch: xalt_epoch.o epoch.o
-	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) -o $@ $^
+	$(LINK.cc) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 $(DESTDIR)$(LIBEXEC)/xalt_syshost: xalt_syshost_main.o xalt_fgets_alloc.o
-	$(LINK.c) -I$(THIS_DIR) $(OPTLVL) $(WARN_FLAGS) -o $@ $^
+	$(LINK.c) -I$(THIS_DIR) $(OPTLVL) $(WARN_FLAGS) $(LDFLAGS) -o $@ $^
 
 __build__/lex.xalt_env.c: $(CURDIR)/__build__/xalt_env_parser.lex
 	flex -P xalt_env -o $@ $^
@@ -249,7 +258,7 @@ xalt_syshost.o: __build__/xalt_syshost.c
 	$(COMPILE.c) -c -o $@ $^
 
 xalt_syshost_main.o: $(CURDIR)/__build__/xalt_syshost.c xalt_fgets_alloc.h
-	$(LINK.c) -I$(THIS_DIR) -c -DHAVE_MAIN $(OPTLVL)  $(WARN_FLAGS) -o $@ $<
+	$(LINK.c) -I$(THIS_DIR) -c -DHAVE_MAIN $(OPTLVL)  $(WARN_FLAGS) $(LDFLAGS) -o $@ $<
 
 
 build_init: $(DESTDIR)$(LIB64)/xalt_quotestring.o     $(DESTDIR)$(LIB64)/xalt_syshost.o            \
@@ -278,7 +287,7 @@ $(DESTDIR)$(BIN)/xalt_test : $(DESTDIR)$(LIB64)/xalt_quotestring.o     $(DESTDIR
                              $(DESTDIR)$(LIB64)/lex.__XALT_path.o      $(DESTDIR)$(LIB64)/lex.__XALT_host.o         \
                              $(DESTDIR)$(LIB64)/build_uuid.o           $(DESTDIR)$(LIB64)/base64.o                  \
                              $(MY_HOSTNAME_PARSER_OBJ)                 $(DESTDIR)$(LIB64)/xalt_test.o
-	$(LINK.c) -g -O0 $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) -o $@ $^ $(LIBUUID) $(LIBDCGM)
+	$(LINK.c) -g -O0 $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) $(LDFLAGS) -o $@ $^ $(LIBUUID) $(LIBDCGM)
 
 
 
@@ -345,7 +354,7 @@ $(DESTDIR)$(LIB)/libxalt_init.so: $(DESTDIR)$(LIB)/xalt_initialize_preload_32.o 
                                   $(DESTDIR)$(LIB)/xalt_fgets_alloc_32.o        \
                                   $(DESTDIR)$(LIB)/base64.o                     \
                                   $(MY_HOSTNAME_PARSER_OBJ_32)
-	$(LINK.c) -m32 $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) -o $@  $^ $(LIBUUID)
+	$(LINK.c) -m32 $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) $(LDFLAGS) -o $@  $^ $(LIBUUID)
 
 
 $(DESTDIR)$(LIB64)/libxalt_init.so: $(DESTDIR)$(LIB64)/xalt_initialize_preload.o \
@@ -357,7 +366,7 @@ $(DESTDIR)$(LIB64)/libxalt_init.so: $(DESTDIR)$(LIB64)/xalt_initialize_preload.o
                                     $(DESTDIR)$(LIB64)/base64.o                  \
                                     $(MY_HOSTNAME_PARSER_OBJ)                    \
                                     $(DESTDIR)$(LIB64)/xalt_fgets_alloc.o
-	$(LINK.c) $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) -o $@  $^ $(LIBUUID) $(LIBDCGM)
+	$(LINK.c) $(CFLAGS) $(CF_INIT) $(LIB_OPTIONS) $(LDFLAGS) -o $@  $^ $(LIBUUID) $(LIBDCGM)
 
 neat:
 	$(RM) *~

--- a/src/Options.C
+++ b/src/Options.C
@@ -165,8 +165,9 @@ Options::Options(int argc, char** argv)
 
       cmd = PATH_TO_PRGM_FILE " " + m_exec;
       capture(cmd, result);
-      if (result[0].find("script") != std::string::npos ||
-          result[0].find("text")   != std::string::npos)
+      if (result.size() > 0 &&
+          (result[0].find("script") != std::string::npos ||
+           result[0].find("text")   != std::string::npos))
         m_exec_type = "script";
       else
         m_exec_type = "binary";

--- a/src/capture.C
+++ b/src/capture.C
@@ -1,11 +1,21 @@
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include "capture.h"
 #define DATA_SIZE 1024
 
 void capture(std::string& cmd, Vstring& result)
 {
   FILE* fp;
+
+  /* swallow stderr */
+  int fd1, fd2;
+  fflush(stderr);
+  fd1 = dup(STDERR_FILENO);
+  fd2 = open("/dev/null", O_WRONLY);
+  dup2(fd2, STDERR_FILENO);
+  close(fd2);
 
   fp = popen(cmd.c_str(), "r");
   if(!fp)
@@ -21,4 +31,9 @@ void capture(std::string& cmd, Vstring& result)
     result.push_back(data);
 
   pclose(fp);
+
+  /* restore stderr */
+  fflush(stderr);
+  dup2(fd1, STDERR_FILENO);
+  close(fd1);
 }


### PR DESCRIPTION
You can inject XALT inside Singularity containers by doing the following:

```
$ SINGULARITYENV_LD_PRELOAD=/host/path/to/xalt/lib64/libxalt_init.so SINGULARITY_BINDPATH="/host/path/to/xalt" SINGULARITY_CONTAINLIBS="/usr/lib64/libdcgm.so.1" singularity shell --nv docker://ubuntu:16.04
```

If you are not tracking GPU usage, then `SINGULARITY_CONTAINLIBS` and `--nv` can be omitted.

These environment variables can be added to the XALT module file to automatically enable XALT tracking of workloads inside Singularity containers.

However, this exposes a few issues which are addressed by this pull request.

1. XALT is linked to `libcrypto.so`.  However the path and version of this library varies depending on the Linux distribution.  So depending on the operating system of the host and the container, there may be a mismatch resulting in a user job failure since `libxalt_init.so` cannot be loaded.  E.g., a CentOS host and a Ubuntu container image.  Add a `configure` option `--with-staticLibs` that will statically link libraries into XALT.  Currently, this only triggers static linking with `libcrypto` and NVIDIA DCGM.  You *must* configure with `--with-staticLibs` in order to confidently use XALT with Singularity containers.

2. The container image may not include the `file` utility.  The `ubuntu:16.04` container image is an example.  XALT will segfault because it assumes there is output from this shell command.  Add a check to ensure there is output before trying to access it.  

3. Related to item 2, if the `file` utility is not present, then an error message is printed to stderr.  Modify `capture()` to swallow anything written to stderr so the user does not see this.

With these changes:

```
$ SINGULARITYENV_XALT_TRACING=yes SINGULARITYENV_LD_PRELOAD=/tmp/usr/local/xalt/xalt/lib64/libxalt_init.so SINGULARITY_BINDPATH="/tmp/usr/local/xalt/xalt" SINGULARITY_CONTAINLIBS="/usr/lib64/libdcgm.so.1" singularity exec --nv ~/ubuntu1604.simg ~/peer
...
---------------------------------------------
 Date:          Thu Oct 11 14:12:38 2018
 XALT Version:  XALT 2.3.12
 Nodename:      ivb125
 System:        Linux
 Release:       3.10.0-862.9.1.el7.x86_64
 O.S. Version:  #1 SMP Mon Jul 16 16:29:36 UTC 2018
 Machine:       x86_64
 Syshost:       psg
---------------------------------------------

myinit(LD_PRELOAD,/home/smcmillan/peer){
  Test for __XALT_INITIAL_STATE__: "(NULL)", STATE: "LD_PRELOAD"
  Test for XALT_EXECUTABLE_TRACKING: yes
  Test for rank == 0, rank: 0
  GPU tracing
    -> XALT is build to track all programs, Current program is a scalar program -> Not producing a start record
}

max error: 1.192093e-07
max error: 1.192093e-07

myfini(LD_PRELOAD){
  GPU tracing
  4 GPUs detected
  GPU 0: num compute pids 1
  GPU 1: num compute pids 1
  GPU 2: num compute pids 0
  GPU 3: num compute pids 0
  2 of 4 GPUs were used
    -> Scalar Sampling program run_time: 0.480286: (my_rand: 0.376318 <= prob: 1) for program: /home/smcmillan/peer
  len: 32, b64_cmd: WyIvaG9tZS9zbWNtaWxsYW4vcGVlciJd
  Recording State at end of scalar user program:
    LD_LIBRARY_PATH= PATH=/usr/bin:/bin /tmp/usr/local/xalt/xalt//libexec/xalt_run_submission --interfaceV 4 --ppid 24242 --syshost "psg" --start "1539267158.9848" --end "1539267159.4651" --exec "/home/smcmillan/peer" --ntasks 1 --uuid "b668d8ad-35cc-4039-8580-3e30338715cf" --prob 1 --ngpus 2 --path "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" --ld_libpath "/.singularity.d/libs" -- ["/home/smcmillan/peer"]
}


xalt_run_submission(zzz) {
  Built envT
  Extracted recordT from executable
  Built userT, userDT
  Filter envT
  Parsed LDD
  Using XALT_TRANSMISSION_STYLE: file
  Built json string
  Wrote json run file : /home/smcmillan/.xalt.d/run.psg.2018_10_11_14_12_38_9848.zzz.b668d8ad-35cc-4039-8580-3e30338715cf.json
}
```